### PR TITLE
fix(client): remove deprecation of vigem_target_ds4_register_notification

### DIFF
--- a/include/ViGEm/Client.h
+++ b/include/ViGEm/Client.h
@@ -109,7 +109,7 @@ extern "C" {
 	/**
 	 * A macro that defines if the API succeeded
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	01.09.2020
 	 *
 	 * @param 	_val_	The error value.
@@ -161,7 +161,7 @@ extern "C" {
 	/**
 	 *  Allocates an object representing a driver connection
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @returns	A PVIGEM_CLIENT object.
@@ -171,7 +171,7 @@ extern "C" {
 	/**
 	 * Frees up memory used by the driver connection object
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem	The PVIGEM_CLIENT object.
@@ -184,7 +184,7 @@ extern "C" {
 	 * Initializes the driver object and establishes a connection to the emulation bus
 	 *          driver. Returns an error if no compatible bus device has been found.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem	The PVIGEM_CLIENT object.
@@ -201,7 +201,7 @@ extern "C" {
 	 *           still be connected will be destroyed automatically. Be aware, that allocated target
 	 *           objects won't be automatically freed, this has to be taken care of by the caller.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem	The PVIGEM_CLIENT object.
@@ -229,7 +229,7 @@ extern "C" {
 	/**
 	 * Allocates an object representing an Xbox 360 Controller device.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @returns	A PVIGEM_TARGET representing an Xbox 360 Controller device.
@@ -239,7 +239,7 @@ extern "C" {
 	/**
 	 * Allocates an object representing a DualShock 4 Controller device.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @returns	A PVIGEM_TARGET representing a DualShock 4 Controller device.
@@ -252,7 +252,7 @@ extern "C" {
 	 *          removed before this call, the device becomes orphaned until the owning process is
 	 *          terminated.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -266,7 +266,7 @@ extern "C" {
 	 *          event of a physical hardware device. This function blocks until the target device is
 	 *          in full operational mode.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -285,7 +285,7 @@ extern "C" {
 	 *          callback may be registered which gets called on error or if the target device has
 	 *          become fully operational.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -306,7 +306,7 @@ extern "C" {
 	 *           after this function is called. If this function is never called on target device
 	 *           objects, they will be removed from the bus when the owning process terminates.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -324,7 +324,7 @@ extern "C" {
 	 *                 occur on the provided target device. This function fails if the provided
 	 *                 target device isn't fully operational or in an erroneous state.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem			The driver connection object.
@@ -342,12 +342,11 @@ extern "C" {
 	);
 
 	/**
-	 * This function is deprecated, use vigem_target_ds4_await_output_report or
-	 * vigem_target_ds4_await_output_report_timeout instead. Registers a function which gets called,
+	 * Registers a function which gets called,
 	 * when LightBar or vibration state changes occur on the provided target device. This function
 	 * fails if the provided target device isn't fully operational or in an erroneous state.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem			The driver connection object.
@@ -357,7 +356,7 @@ extern "C" {
 	 *
 	 * @returns	A VIGEM_ERROR.
 	 */
-	VIGEM_API VIGEM_DEPRECATED VIGEM_ERROR vigem_target_ds4_register_notification(
+	VIGEM_API VIGEM_ERROR vigem_target_ds4_register_notification(
 		PVIGEM_CLIENT vigem,
 		PVIGEM_TARGET target,
 		PFN_VIGEM_DS4_NOTIFICATION notification,
@@ -367,7 +366,7 @@ extern "C" {
 	/**
 	 * Removes a previously registered callback function from the provided target object.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -379,7 +378,7 @@ extern "C" {
 	/**
 	 * Removes a previously registered callback function from the provided target object.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -391,7 +390,7 @@ extern "C" {
 	/**
 	 * Overrides the default Vendor ID value with the provided one.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -405,7 +404,7 @@ extern "C" {
 	/**
 	 * Overrides the default Product ID value with the provided one.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -419,7 +418,7 @@ extern "C" {
 	/**
 	 * Returns the Vendor ID of the provided target device object.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -433,7 +432,7 @@ extern "C" {
 	/**
 	 * Returns the Product ID of the provided target device object.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -447,7 +446,7 @@ extern "C" {
 	/**
 	 * Sends a state report to the provided target device.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -466,7 +465,7 @@ extern "C" {
 	 * DEPRECATED. Sends a state report to the provided target device. It's recommended to use
 	 * vigem_target_ds4_update_ex instead to utilize all DS4 features like touch, gyro etc.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -485,7 +484,7 @@ extern "C" {
 	 * Sends a full size state report to the provided target device. It's recommended to use this
 	 * function over vigem_target_ds4_update.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	07.09.2020
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -509,7 +508,7 @@ extern "C" {
 	 *               device is removed from the bus and may change on the next addition of the
 	 *               device.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -523,7 +522,7 @@ extern "C" {
 	/**
 	 * Returns the type of the provided target device object.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	28.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -538,7 +537,7 @@ extern "C" {
 	 * Returns TRUE if the provided target device object is currently attached to the bus,
 	 *              FALSE otherwise.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	30.08.2017
 	 *
 	 * @param 	target	The target device object.
@@ -555,7 +554,7 @@ extern "C" {
 	 *                physical controller and is compatible to the dwUserIndex property of the
 	 *                XInput* APIs.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger
+	 * @author	Benjamin "Nefarius" HÃ¶glinger
 	 * @date	10.05.2018
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -578,7 +577,7 @@ extern "C" {
 	 * is recommended to repeatedly call this function in a thread. The call aborts with an error
 	 * code if the target gets unplugged in parallel.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	06.08.2022
 	 *
 	 * @param 	vigem 	The driver connection object.
@@ -604,7 +603,7 @@ extern "C" {
 	 * parallel. If a timeout of INFINITE is specified, the function basically behaves identical to
 	 * vigem_target_ds4_await_output_report.
 	 *
-	 * @author	Benjamin "Nefarius" Höglinger-Stelzer
+	 * @author	Benjamin "Nefarius" HÃ¶glinger-Stelzer
 	 * @date	12.08.2022
 	 *
 	 * @param 	vigem			The driver connection object.


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Removes a deprecation warning.

Additionally, the encoding was changed to UTF-8 upon updating this file.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
